### PR TITLE
Update immich.yml

### DIFF
--- a/compose/immich.env
+++ b/compose/immich.env
@@ -1,54 +1,19 @@
-###################################################################################
-# Database
-###################################################################################
+# You can find documentation for all the supported env variables at https://immich.app/docs/install/environment-variables
 
-DB_HOSTNAME=immich_postgres
-DB_USERNAME=postgres
-DB_PASSWORD=postgres
-DB_DATABASE_NAME=immich
-
-# Optional Database settings:
-# DB_PORT=5432
-
-###################################################################################
-# Redis
-###################################################################################
-
-REDIS_HOSTNAME=immich_redis
-
-# Optional Redis settings:
-# REDIS_PORT=6379
-# REDIS_DBINDEX=0
-# REDIS_PASSWORD=
-# REDIS_SOCKET=
-
-###################################################################################
-# Upload File Location
-#
-# This is the location where uploaded files are stored.
-###################################################################################
-
+# The location where your uploaded files are stored
 UPLOAD_LOCATION=/mnt/unionfs/Media/Photos
 
+# The Immich version to use. You can pin this to a specific version like "v1.71.0"
+IMMICH_VERSION=release
+
+# Connection secrets for postgres and typesense. You should change these to random passwords
+TYPESENSE_API_KEY=super-duper-strong-password-salty-is-the-best
+DB_PASSWORD=postgres
+
+# The values below this line do not need to be changed
 ###################################################################################
-# Reverse Geocoding
-#
-# Reverse geocoding is done locally which has a small impact on memory usage
-# This memory usage can be altered by changing the REVERSE_GEOCODING_PRECISION variable
-# This ranges from 0-3 with 3 being the most precise
-# 3 - Cities > 500 population: ~200MB RAM
-# 2 - Cities > 1000 population: ~150MB RAM
-# 1 - Cities > 5000 population: ~80MB RAM
-# 0 - Cities > 15000 population: ~40MB RAM
-####################################################################################
+DB_HOSTNAME=immich_postgres
+DB_USERNAME=postgres
+DB_DATABASE_NAME=immich
 
-# DISABLE_REVERSE_GEOCODING=false
-# REVERSE_GEOCODING_PRECISION=3
-
-####################################################################################
-# Custom message on the login page, should be written in HTML form.
-# For example:
-# PUBLIC_LOGIN_PAGE_MESSAGE="This is a demo instance of Immich.<br><br>Email: <i>demo@demo.de</i><br>Password: <i>demo</i>"
-####################################################################################
-
-PUBLIC_LOGIN_PAGE_MESSAGE=
+REDIS_HOSTNAME=immich_redis

--- a/compose/immich.yml
+++ b/compose/immich.yml
@@ -2,101 +2,170 @@ version: "3.8"
 
 services:
   immich-server:
-    image: altran1502/immich-server:release
-    entrypoint: ["/bin/sh", "./start-server.sh"]
+    container_name: immich_server
+    hostname: immich_server
+    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
+    labels:
+      com.github.saltbox.saltbox_managed: true
+    environment:
+      - PUID=1000
+      - PGID=1001
+    networks:
+      - saltbox
+    command: ["start.sh", "immich"]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
+      - /etc/localtime:/etc/localtime:ro
     env_file:
       - .env
-    environment:
-      - NODE_ENV=production
     depends_on:
       - redis
       - database
+      - typesense
     restart: always
 
   immich-microservices:
-    image: altran1502/immich-server:release
-    entrypoint: ["/bin/sh", "./start-microservices.sh"]
+    container_name: immich_microservices
+    hostname: immich_microservices
+    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
+    labels:
+      com.github.saltbox.saltbox_managed: true
+    environment:
+      - PUID=1000
+      - PGID=1001
+    networks:
+      - saltbox
+    extends:
+      file: hwaccel.yml
+      service: hwaccel
+    command: ["start.sh", "microservices"]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
+      - /etc/localtime:/etc/localtime:ro
     env_file:
       - .env
-    environment:
-      - NODE_ENV=production
     depends_on:
       - redis
       - database
+      - typesense
     restart: always
 
   immich-machine-learning:
-    image: altran1502/immich-machine-learning:release
-    entrypoint: ["/bin/sh", "./entrypoint.sh"]
+    container_name: immich_machine_learning
+    hostname: immich_machine_learning
+    image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
+    labels:
+      com.github.saltbox.saltbox_managed: true
+    environment:
+      - PUID=1000
+      - PGID=1001
+    networks:
+      - saltbox
     volumes:
-      - ${UPLOAD_LOCATION}:/usr/src/app/upload
+      - /opt/immich/model-cache:/cache
     env_file:
       - .env
-    environment:
-      - NODE_ENV=production
-    depends_on:
-      - database
     restart: always
 
   immich-web:
-    image: altran1502/immich-web:release
-    entrypoint: ["/bin/sh", "./entrypoint.sh"]
+    container_name: immich_web
+    hostname: immich_web
+    image: ghcr.io/immich-app/immich-web:${IMMICH_VERSION:-release}
+    labels:
+      com.github.saltbox.saltbox_managed: true
+    environment:
+      - PUID=1000
+      - PGID=1001
+    networks:
+      - saltbox
     env_file:
       - .env
+    restart: always
+
+  typesense:
+    container_name: immich_typesense
+    hostname: immich_typesense
+    image: typesense/typesense:0.24.1@sha256:9bcff2b829f12074426ca044b56160ca9d777a0c488303469143dd9f8259d4dd
+    labels:
+      com.github.saltbox.saltbox_managed: true
+    networks:
+      - saltbox
+    environment:
+      - PUID=1000
+      - PGID=1001
+      - TYPESENSE_API_KEY=${TYPESENSE_API_KEY}
+      - TYPESENSE_DATA_DIR=/data
+      # remove this to get debug messages
+      - GLOG_minloglevel=1
+    volumes:
+      - /opt/immich/tsdata:/data
     restart: always
 
   redis:
     container_name: immich_redis
-    image: redis:6.2
+    hostname: immich_redis
+    image: redis:6.2-alpine@sha256:70a7a5b641117670beae0d80658430853896b5ef269ccf00d1827427e3263fa3
+    labels:
+      com.github.saltbox.saltbox_managed: true
+    environment:
+      - PUID=1000
+      - PGID=1001
+    networks:
+      - saltbox
     restart: always
 
   database:
     container_name: immich_postgres
-    image: postgres:14
+    hostname: immich_postgres
+    image: postgres:14-alpine@sha256:28407a9961e76f2d285dc6991e8e48893503cc3836a4755bbc2d40bcc272a441
+    labels:
+      com.github.saltbox.saltbox_managed: true
+    networks:
+      - saltbox
     env_file:
       - .env
     environment:
+      PUID: 1000
+      PGID: 1001
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_DB: ${DB_DATABASE_NAME}
-      PG_DATA: /var/lib/postgresql/data
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - /opt/immich/pgdata:/var/lib/postgresql/data
     restart: always
 
   immich-proxy:
     container_name: immich_proxy
-    image: altran1502/immich-proxy:release
+    hostname: immich_proxy
+    image: ghcr.io/immich-app/immich-proxy:${IMMICH_VERSION:-release}
+    labels:
+      com.github.saltbox.saltbox_managed: true
+    environment:
+      - PUID=1000
+      - PGID=1001
     networks:
-      - default
       - saltbox
     labels:
+      com.github.saltbox.saltbox_managed: true
       diun.enable: true
       traefik.enable: true
       traefik.docker.network: saltbox
       traefik.http.routers.immich-http.entrypoints: web
       traefik.http.routers.immich-http.middlewares: globalHeaders@file,redirect-to-https,gzip
-      traefik.http.routers.immich-http.rule: Host(`immich.TLD.COM`)
+      traefik.http.routers.immich-http.rule: Host(`immich.APPNAME.TLD`)
       traefik.http.routers.immich-http.service: immich
       traefik.http.routers.immich.entrypoints: websecure
       traefik.http.routers.immich.middlewares: globalHeaders@file,secureHeaders@file
-      traefik.http.routers.immich.rule: Host(`immich.TLD.COM`)
+      traefik.http.routers.immich.rule: Host(`immich.APPNAME.TLD`)
       traefik.http.routers.immich.service: immich
       traefik.http.routers.immich.tls.certresolver: cfdns
       traefik.http.routers.immich.tls.options: securetls@file
       traefik.http.services.immich.loadbalancer.server.port: 8080
-    logging:
-      driver: none
     depends_on:
       - immich-server
+      - immich-web
     restart: always
 
-volumes:
-  pgdata:
 networks:
   saltbox:
     external: true

--- a/compose/immich.yml
+++ b/compose/immich.yml
@@ -17,7 +17,7 @@ services:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro
     env_file:
-      - .env
+      - immich.env
     depends_on:
       - redis
       - database
@@ -43,7 +43,7 @@ services:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro
     env_file:
-      - .env
+      - immich.env
     depends_on:
       - redis
       - database
@@ -64,7 +64,7 @@ services:
     volumes:
       - /opt/immich/model-cache:/cache
     env_file:
-      - .env
+      - immich.env
     restart: always
 
   immich-web:
@@ -79,7 +79,7 @@ services:
     networks:
       - saltbox
     env_file:
-      - .env
+      - immich.env
     restart: always
 
   typesense:
@@ -123,7 +123,7 @@ services:
     networks:
       - saltbox
     env_file:
-      - .env
+      - immich.env
     environment:
       PUID: 1000
       PGID: 1001

--- a/compose/readme/Immich.md
+++ b/compose/readme/Immich.md
@@ -1,0 +1,24 @@
+# Immich
+
+You will need to create an A record in cloudflare or whomever your provider is for this to resolve, or alternatively, run the ddns role salty made, to automatically create the records in cloudflare. (`sb install ddns`) It works similarly to the regular roles, and will add a record for you for docker compose files. Make sure to edit the `labels` section of the compose file with your domain and top level domain. (IE `immich.APPNAME.TLD) Then correct any of the other things that may be different for you, which I'll list:
+
+1. User mapping:
+```yaml
+    environment:
+      - PUID=1000
+      - PGID=1001
+```
+to find your puid & guid, type `id` in your terminal, and put the corresponding numbers in each puid & pgid env in the compose. This will correct any permissions issues.
+
+2. Create the subdirectories for each container under the root dir you are holding the compose file in. If you don't like the `/opt/immich` dir be sure to update them all accordingly. If you don't create the subdirectories they'll be owned by root, and you'll need to correct that manually.
+`mkdir -p /opt/immich/model-cache` for example, according to the machine learning container.
+ie:
+
+```yaml
+    volumes:
+      - /opt/immich/model-cache:/cache
+```
+
+3. Lastly, and I'm not sure if this is necessary, run this to allow you to change your name from admin to whatever you choose. `docker exec immich_server sed -i 's/$1/$@/g' /usr/src/app/start.sh`
+
+Happy image processing!


### PR DESCRIPTION
Updating the compose file to be more in line with the current default for Immich. Added the saltbox managed label to each container. added user mapping to each container as well, as the majority of them will accept it. Removed default volumes in liu of the saltbox standard `/opt/appname` directories. Additional container added (typesense) since its also now included in the default.