### PR TITLE
feat: add panelarr role

### DIFF
--- a/roles/panelarr/defaults/main.yml
+++ b/roles/panelarr/defaults/main.yml
@@ -1,0 +1,147 @@
+##########################################################################
+# Title:         Sandpit: Panelarr | Default Variables                   #
+# Author(s):     thug-drama                                              #
+# URL:           https://github.com/saltyorg/Sandpit                     #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+panelarr_name: panelarr
+
+################################
+# Paths
+################################
+
+panelarr_paths_folder: "{{ panelarr_name }}"
+panelarr_paths_location: "{{ server_appdata_path }}/{{ panelarr_paths_folder }}"
+panelarr_paths_folders_list:
+  - "{{ panelarr_paths_location }}"
+
+################################
+# Web
+################################
+
+panelarr_web_subdomain: "{{ panelarr_name }}"
+panelarr_web_domain: "{{ user.domain }}"
+panelarr_web_port: "8000"
+panelarr_web_url: "{{ 'https://' + (panelarr_web_subdomain + '.' + panelarr_web_domain
+                   if (panelarr_web_subdomain | length > 0)
+                   else panelarr_web_domain) }}"
+
+################################
+# DNS
+################################
+
+panelarr_dns_record: "{{ panelarr_web_subdomain }}"
+panelarr_dns_zone: "{{ panelarr_web_domain }}"
+panelarr_dns_proxy: "{{ dns.proxied }}"
+
+################################
+# Traefik
+################################
+
+panelarr_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+panelarr_traefik_middleware_default: "{{ traefik_default_middleware }}"
+panelarr_traefik_middleware_custom: ""
+panelarr_traefik_certresolver: "{{ traefik_default_certresolver }}"
+panelarr_traefik_enabled: true
+panelarr_traefik_api_enabled: true
+panelarr_traefik_api_endpoint: "PathPrefix(`/api`) || PathPrefix(`/ws`)"
+
+################################
+# Docker
+################################
+
+# Container
+panelarr_docker_container: "{{ panelarr_name }}"
+
+# Image
+panelarr_docker_image_pull: true
+panelarr_docker_image_tag: "latest"
+panelarr_docker_image: "ghcr.io/thug-drama/panelarr:{{ panelarr_docker_image_tag }}"
+
+# Ports
+panelarr_docker_ports_defaults: []
+panelarr_docker_ports_custom: []
+panelarr_docker_ports: "{{ panelarr_docker_ports_defaults
+                           + panelarr_docker_ports_custom }}"
+
+# Envs
+panelarr_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+panelarr_docker_envs_custom: {}
+panelarr_docker_envs: "{{ panelarr_docker_envs_default
+                          | combine(panelarr_docker_envs_custom) }}"
+
+# Commands
+panelarr_docker_commands_default: []
+panelarr_docker_commands_custom: []
+panelarr_docker_commands: "{{ panelarr_docker_commands_default
+                              + panelarr_docker_commands_custom }}"
+
+# Volumes
+panelarr_docker_volumes_default:
+  - "{{ panelarr_paths_location }}:/config"
+  - "/var/run/docker.sock:/var/run/docker.sock:ro"
+panelarr_docker_volumes_custom: []
+panelarr_docker_volumes: "{{ panelarr_docker_volumes_default
+                             + panelarr_docker_volumes_custom }}"
+
+# Devices
+panelarr_docker_devices_default: []
+panelarr_docker_devices_custom: []
+panelarr_docker_devices: "{{ panelarr_docker_devices_default
+                             + panelarr_docker_devices_custom }}"
+
+# Hosts
+panelarr_docker_hosts_default: []
+panelarr_docker_hosts_custom: []
+panelarr_docker_hosts: "{{ docker_hosts_common
+                           | combine(panelarr_docker_hosts_default)
+                           | combine(panelarr_docker_hosts_custom) }}"
+
+# Labels
+panelarr_docker_labels_default: {}
+panelarr_docker_labels_custom: {}
+panelarr_docker_labels: "{{ docker_labels_common
+                            | combine(panelarr_docker_labels_default)
+                            | combine(panelarr_docker_labels_custom) }}"
+
+# Hostname
+panelarr_docker_hostname: "{{ panelarr_name }}"
+
+# Networks
+panelarr_docker_networks_alias: "{{ panelarr_name }}"
+panelarr_docker_networks_default: []
+panelarr_docker_networks_custom: []
+panelarr_docker_networks: "{{ docker_networks_common
+                              + panelarr_docker_networks_default
+                              + panelarr_docker_networks_custom }}"
+
+# Capabilities
+panelarr_docker_capabilities_default:
+  - CHOWN
+  - SETUID
+  - SETGID
+panelarr_docker_capabilities_custom: []
+panelarr_docker_capabilities: "{{ panelarr_docker_capabilities_default
+                                  + panelarr_docker_capabilities_custom }}"
+
+# Security Opts
+panelarr_docker_security_opts_default: []
+panelarr_docker_security_opts_custom: []
+panelarr_docker_security_opts: "{{ panelarr_docker_security_opts_default
+                                   + panelarr_docker_security_opts_custom }}"
+
+# Restart Policy
+panelarr_docker_restart_policy: unless-stopped
+
+# State
+panelarr_docker_state: started

--- a/roles/panelarr/tasks/main.yml
+++ b/roles/panelarr/tasks/main.yml
@@ -1,0 +1,24 @@
+#########################################################################
+# Title:            Sandpit: Panelarr                                   #
+# Author(s):        thug-drama                                          #
+# URL:              https://github.com/saltyorg/Sandpit                 #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+    dns_proxy: "{{ lookup('vars', role_name + '_dns_proxy') }}"
+
+- name: Remove existing Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/directories/create_directories.yml"
+
+- name: Create Docker container
+  ansible.builtin.include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/sandpit.yml
+++ b/sandpit.yml
@@ -19,6 +19,7 @@
     - { role: immich_machine_learning, tags: ['immich_machine_learning'] }
     - { role: immich_typesense, tags: ['immich_typesense'] }
     - { role: maintainerr, tags: ['maintainerr'] }
+    - { role: panelarr, tags: ['panelarr'] }
     - { role: profilarr, tags: ['profilarr', 'profilarr-backup', 'profilarr-reset'] }
     - { role: spotweb, tags: ['spotweb'] }
     - { role: zigbee2mqtt, tags: ['zigbee2mqtt'] }


### PR DESCRIPTION
## Summary

Adds a Sandpit role for [Panelarr](https://github.com/thug-drama/panelarr), a self-hosted control center for Docker-based media stacks.

Single Docker container that manages Sonarr, Radarr, qBittorrent, SABnzbd, Plex, Jellyfin, and Docker containers from one dashboard. Not a start page. It talks to the actual APIs so you can take action: blocklist downloads, restart containers, search missing episodes, stream live logs, manage seeding torrents.

- GHCR image at `ghcr.io/thug-drama/panelarr:latest` (amd64 + arm64)
- Docker socket mounted read-only for container management
- Config persisted to standard appdata path at `/config`
- Port 8000 internal, Traefik routing with SSO middleware
- API and WebSocket paths exposed via Traefik
- Setup wizard auto-discovers Sonarr/Radarr/SABnzbd/qBit/Plex/Jellyfin on the network and pre-fills service URLs
- Four auth modes: none, basic (JWT), proxy (Authelia/Authentik), apikey

After install: open `https://panelarr.yourdomain.com`, finish the setup wizard. No config file editing needed.

**Project:** https://github.com/thug-drama/panelarr
**Site:** https://panelarr.dev
**License:** MIT